### PR TITLE
fix: regressão use_container_width quebra página de recomendação (Streamlit 1.37.1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,7 @@ def select_product():
     produto = products.iloc[st.session_state.nproduct]
 
     col1, col2, col3 = st.columns([1,3,1])
-    col2.image(produto['thumbnail'], caption=produto['name'], use_container_width=True)
+    col2.image(produto['thumbnail'], caption=produto['name'], use_column_width=True)
 
     preco = _formata_preco(produto.get('price'))
     if preco:


### PR DESCRIPTION
## Problema

Ao usar a aplicação em produção, a página de recomendação de produtos quebrava com:

```
TypeError: ImageMixin.image() got an unexpected keyword argument 'use_container_width'
```

O argumento `use_container_width` em `st.image()` só passou a existir em versões mais recentes do Streamlit (>= 1.41). Como o `requirements.txt` fixa `streamlit==1.37.1` (versão em produção), a chamada falhava sempre que um produto era exibido.

Regressão introduzida na Sprint 1 (troca de `use_column_width` por `use_container_width`).

## Correção

Reverte para `use_column_width=True`, compatível com a versão fixada. Validado rodando a aplicação contra a API de produção: a página de recomendação volta a renderizar imagem, preço e o link "Ver Loja" corretamente.

> Quando o Streamlit for atualizado para >= 1.41, vale voltar a `use_container_width` (e atualizar o pin no `requirements.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
